### PR TITLE
Fix container property for ONNX binary extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ This project includes [ONNX Runtime](https://github.com/microsoft/onnxruntime), 
 - Bundled for convenience in `resources/native` (`onnxruntime.dll` / `libonnxruntime.so`)
 
 A copy of the original license is included in [`LICENSE-ONNX.txt`](./src/main/resources/native/LICENSE-ONNX.txt).
+
+### 🔨 Building ONNX Runtime
+
+The native ONNX Runtime library is built and packaged via the
+`onnxruntime-binaries` module. When running on Linux or macOS it uses a
+Docker image to compile the library; on Windows the build runs directly
+through `build-native.bat`.
+
+Generate the JAR containing the platform specific binaries with:
+
+```bash
+./gradlew :onnxruntime-native:onnxruntime-binaries:nativeJar
+```
+
+You can specify a different target or enable CUDA by supplying the
+`nativeTarget` and `enableCuda` properties. The extraction task creates a
+temporary container whose name is controlled by the `containerName`
+property.

--- a/onnxruntime-native/onnxruntime-binaries/build.gradle.kts
+++ b/onnxruntime-native/onnxruntime-binaries/build.gradle.kts
@@ -17,7 +17,7 @@ val outputFile = layout.buildDirectory.file("libonnxruntime-$targetClassifier.$l
 
 val dockerFileName = "Dockerfile.$targetClassifier" + if (enableCuda) ".cuda" else ".cpu"
 val dockerImage = "onnxruntime-builder:$targetClassifier" + if (enableCuda) "-cuda" else "-cpu"
-val containerName = "onnxruntime-tmp-$targetClassifier" + if (enableCuda) "-cuda" else "-cpu"
+val containerNameValue = "onnxruntime-tmp-$targetClassifier" + if (enableCuda) "-cuda" else "-cpu"
 
 val buildDockerImage by tasks.registering(Exec::class) {
     group = "build"
@@ -43,7 +43,7 @@ val extractSo = tasks.register<ExtractSoTask>("extractSo") {
     dependsOn(buildDockerImage)
     onlyIf { !isWindows }
     image.set(dockerImage)
-    containerName.set(containerName)
+    containerName.set(containerNameValue)
     output.set(outputFile)
 }
 


### PR DESCRIPTION
## Summary
- fix variable name collision in `onnxruntime-binaries` Gradle script
- document how to build ONNX Runtime from the module

## Testing
- `gradle build -x :onnxruntime-native:onnxruntime-binaries:buildDockerImage -x :onnxruntime-native:onnxruntime-binaries:extractSo`

------
https://chatgpt.com/codex/tasks/task_e_686d5f1b55d08320b9260daf73b913e9